### PR TITLE
fix helptext parsing accross paragraph's

### DIFF
--- a/src/attribute/help.rs
+++ b/src/attribute/help.rs
@@ -91,7 +91,7 @@ fn parse_help_text(input: KconfigInput) -> IResult<KconfigInput, String> {
 
     help_text.insert_str(0, &first_line);
 
-    Ok((remaining, help_text)) // Return remaining input and parsed text
+    Ok((remaining, help_text.trim().to_string()))
 }
 
 fn parse_line_help(input: KconfigInput) -> IResult<KconfigInput, (KconfigInput, KconfigInput)> {

--- a/src/attribute/help_test.rs
+++ b/src/attribute/help_test.rs
@@ -104,7 +104,7 @@ fn test_parse_help_indentation_preservation() {
         input,
         Ok((
             "",
-            "Lorem Ipsum\n    - Lorem Ipsum\nLorem Ipsum\n".to_string()
+            "Lorem Ipsum\n    - Lorem Ipsum\nLorem Ipsum".to_string()
         ))
     )
 }

--- a/src/attribute/help_test.rs
+++ b/src/attribute/help_test.rs
@@ -108,3 +108,17 @@ fn test_parse_help_indentation_preservation() {
         ))
     )
 }
+
+#[test]
+fn test_parse_help_double_newline() {
+    let input = r"help
+      bla 1
+        bla 2
+
+      bla 3";
+    assert_parsing_eq!(
+        parse_help,
+        input,
+        Ok(("", "bla 1\n  bla 2\n\nbla 3".to_string()))
+    )
+}

--- a/src/entry/mod_test.rs
+++ b/src/entry/mod_test.rs
@@ -62,7 +62,7 @@ fn test_double_indented_entries() {
                             r#if: None
                         }),
                         Attribute::Help(
-                            "- Lorem ipsum dolor sit amet, consetetur sadipscing elitr.\n    - Lorem ipsum dolor sit amet, consetetur sadipscing elitr.\n".to_string()
+                            "- Lorem ipsum dolor sit amet, consetetur sadipscing elitr.\n    - Lorem ipsum dolor sit amet, consetetur sadipscing elitr.\n\n".to_string()
                         )
                     )
                 }),

--- a/src/entry/mod_test.rs
+++ b/src/entry/mod_test.rs
@@ -62,7 +62,7 @@ fn test_double_indented_entries() {
                             r#if: None
                         }),
                         Attribute::Help(
-                            "- Lorem ipsum dolor sit amet, consetetur sadipscing elitr.\n    - Lorem ipsum dolor sit amet, consetetur sadipscing elitr.\n\n".to_string()
+                            "- Lorem ipsum dolor sit amet, consetetur sadipscing elitr.\n    - Lorem ipsum dolor sit amet, consetetur sadipscing elitr.".to_string()
                         )
                     )
                 }),

--- a/src/lib_test.rs
+++ b/src/lib_test.rs
@@ -182,7 +182,7 @@ config AS_WRUSS
                             ))),
                             r#if: None
                         },),
-                        Attribute::Help("Supported by binutils\n".to_string())
+                        Attribute::Help("Supported by binutils".to_string())
                     )
                 }),)
             },


### PR DESCRIPTION
I missed the newline paragraph parsing. Yeah that is a bit ugly, since technically a standalone newline did decrees the indentation compared to the initial one :D 

closes #65 