### PR TITLE
Ability to specify variables that included sources file depend on

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nom-kconfig"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 authors = ["yann Prono"]
 repository = "https://github.com/Mcdostone/nom-kconfig"

--- a/src/entry/source.rs
+++ b/src/entry/source.rs
@@ -34,38 +34,55 @@ pub fn parse_source(input: KconfigInput) -> IResult<KconfigInput, Source> {
         delimited(tag("\""), parse_filepath, tag("\"")),
         parse_filepath,
     )))(input)?;
-    let source_kconfig_file = KconfigFile::new(input.clone().extra.root_dir, PathBuf::from(file));
-    if is_dynamic_source(file) {
-        return Ok((
+    if let Some(file) = apply_vars(file, &input.extra.vars) {
+        let source_kconfig_file = KconfigFile::new_with_vars(
+            input.clone().extra.root_dir, PathBuf::from(file), &input.extra.vars);
+        let source_content = source_kconfig_file
+            .read_to_string()
+            .map_err(|_| nom::Err::Error(Error::from_error_kind(input.clone(), ErrorKind::Fail)))?;
+
+        let binding = source_content.clone();
+        #[allow(clippy::let_and_return)]
+        let x = match cut(parse_kconfig)(KconfigInput::new_extra(
+            &binding,
+            source_kconfig_file.clone(),
+        )) {
+            Ok((_, kconfig)) => Ok((input, kconfig)),
+            Err(_e) => Err(nom::Err::Error(nom::error::Error::new(
+                KconfigInput::new_extra("", source_kconfig_file),
+                ErrorKind::Fail,
+            ))),
+        };
+        x
+    } else {
+        Ok((
             input,
             Source {
                 file: file.to_string(),
                 ..Default::default()
             },
-        ));
+        ))
     }
-    let source_content = source_kconfig_file
-        .read_to_string()
-        .map_err(|_| nom::Err::Error(Error::from_error_kind(input.clone(), ErrorKind::Fail)))?;
-
-    let binding = source_content.clone();
-    #[allow(clippy::let_and_return)]
-    let x = match cut(parse_kconfig)(KconfigInput::new_extra(
-        &binding,
-        source_kconfig_file.clone(),
-    )) {
-        Ok((_, kconfig)) => Ok((input, kconfig)),
-        Err(_e) => Err(nom::Err::Error(nom::error::Error::new(
-            KconfigInput::new_extra("", source_kconfig_file),
-            ErrorKind::Fail,
-        ))),
-    };
-    x
 }
 
-fn is_dynamic_source(file: &str) -> bool {
-    let re = Regex::new("\\$(.+)").unwrap();
-    re.is_match(file)
+pub fn apply_vars(file: &str, extra_vars: &std::collections::HashMap<String, String>) -> Option<String> {
+    let re = Regex::new(r"\$\((\S+)\)").unwrap();
+    let mut file_copy = String::from(file);
+    for (var_name, var_value) in re
+        .captures_iter(file)
+        .map(|cap| {
+            let ex: (&str, [&str; 1]) = cap.extract();
+            let var = ex.1[0];
+            (var, extra_vars.get(var))
+        })
+    {
+        if let Some(var_value) = var_value {
+            file_copy = file_copy.replace(&format!("$({var_name})"), &var_value);
+        } else {
+            return None;
+        }
+    }
+    Some(file_copy)
 }
 
 /// Entry that reads the specified configuration file. This file is always parsed.

--- a/src/entry/source_test.rs
+++ b/src/entry/source_test.rs
@@ -1,7 +1,7 @@
-use std::path::PathBuf;
+use std::{collections::HashMap, path::PathBuf};
 
 use crate::{
-    entry::{parse_source, Source},
+    entry::{parse_source, source::apply_vars, Source},
     Kconfig, KconfigFile, KconfigInput,
 };
 
@@ -71,4 +71,21 @@ fn assert_parsing_source_eq(
     ))
     .map(|r| (r.0.fragment().to_owned(), r.1));
     assert_eq!(res, expected)
+}
+
+fn assert_apply_env_vars(s: &str, extra_vars: &[(&str, &str)], expected: Option<&str>) {
+    let extra_vars: HashMap<String, String> = extra_vars
+        .into_iter()
+        .map(|(s1, s2)| (s1.to_string(), s2.to_string())).collect();
+    assert_eq!(apply_vars(s, &extra_vars), expected.map(String::from));
+}
+
+#[test]
+fn test_apply_env_vars() {
+    assert_apply_env_vars("123 $(NON_EXISTENT_VAR) 456", &[], None);
+    assert_apply_env_vars("123 $(NON_EXISTENT_VAR) 456", &[("USELESS_VAR", "789")], None);
+    assert_apply_env_vars("123", &[], Some("123"));
+    assert_apply_env_vars("123", &[("USELESS_VAR", "789")], Some("123"));
+    assert_apply_env_vars("123 $(GOOD_VAR) 456", &[("GOOD_VAR", "Bingo")], Some("123 Bingo 456"));
+    assert_apply_env_vars("123 $(GOOD_VAR) 456 $(GOOD_VAR)", &[("GOOD_VAR", "Bingo")], Some("123 Bingo 456 Bingo"));
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ use nom_locate::LocatedSpan;
 
 use std::path::PathBuf;
 use std::{fs, io};
+use std::collections::HashMap;
 
 pub mod attribute;
 pub mod entry;
@@ -46,11 +47,17 @@ pub struct KconfigFile {
     root_dir: PathBuf,
     /// The path the the Kconfig you want to parse.
     file: PathBuf,
+    /// Externally-specified variables to use when including child source files
+    vars: HashMap<String, String>,
 }
 
 impl KconfigFile {
     pub fn new(root_dir: PathBuf, file: PathBuf) -> Self {
-        Self { root_dir, file }
+        Self { root_dir, file, vars: HashMap::new() }
+    }
+
+    pub fn new_with_vars<S: AsRef<str>>(root_dir: PathBuf, file: PathBuf, vars: &HashMap<S, S>) -> Self {
+        Self { root_dir, file, vars: vars.into_iter().map(|(s1, s2)| (s1.as_ref().to_string(), s2.as_ref().to_string())).collect() }
     }
 
     pub fn full_path(&self) -> PathBuf {
@@ -59,6 +66,10 @@ impl KconfigFile {
 
     pub fn read_to_string(&self) -> io::Result<String> {
         fs::read_to_string(self.full_path())
+    }
+
+    pub fn set_vars<S: AsRef<str>>(&mut self, vars: &[(S, S)]) {
+        self.vars = vars.into_iter().map(|(s1, s2)| (s1.as_ref().to_string(), s2.as_ref().to_string())).collect();
     }
 }
 


### PR DESCRIPTION
If this crate is directed towards a normal linux kernel source tree, a lot of files are not parsed as they are included like this:

`source "arch/$(SRCARCH)/Kconfig"`
`source "arch/$(HEADER_ARCH)/um/Kconfig"`

The variables `SRCARCH` and `HEADER_ARCH` are set by the MAKE process of linux kernel and cannot be deduced from Kconfig files. Therefore I'm adding the API to set such variables by hand, if one wants them. For example:

```
let mut kconfig_file = KconfigFile::new(
        PathBuf::from("/path/to/linux.git"),
        PathBuf::from("/path/to/linux.git/Kconfig")
);
kconfig_file.set_vars(&[("SRCARCH", "x86")]);
```

To preserve the backward compatibility, I'm not modifying the existing `new()` function, instead I'm adding a pair of additional functions to `KconfigFile` interface.
