### PR TITLE
Use regex-lite instead of regex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -965,7 +965,7 @@ dependencies = [
  "glob",
  "nom",
  "nom_locate",
- "regex",
+ "regex-lite",
  "reqwest",
  "serde",
  "tracing",
@@ -1245,6 +1245,12 @@ dependencies = [
  "memchr",
  "regex-syntax",
 ]
+
+[[package]]
+name = "regex-lite"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
 
 [[package]]
 name = "regex-syntax"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ members = [
 glob = { version = "0.3.3", optional = true }
 nom = "8.0.0"
 nom_locate = "5.0.0"
-regex = "1.12.3"
+regex-lite = "0.1.9"
 serde = { version = "1.0.228", features = ["derive"], optional = true }
 tracing = { version = "0.1.44", features = ["log"] }
 

--- a/src/entry/source.rs
+++ b/src/entry/source.rs
@@ -12,7 +12,7 @@ use nom::{
     sequence::delimited,
     IResult, Parser,
 };
-use regex::Regex;
+use regex_lite::Regex;
 #[cfg(feature = "deserialize")]
 use serde::Deserialize;
 #[cfg(feature = "serialize")]


### PR DESCRIPTION
Regex is actually used quite minimally in `nom-kconfig`, and `regex-lite` is much smaller than `regex`.

### Background:

I'm trying to reduce the number of dependencies that are getting pulled in by the crates that `kconfirm` depends on, as requested by the linux maintainers, e.g.:
```
This adds too many dependencies.
```
source: https://lore.kernel.org/all/8fe7c7c8-00f7-4a72-a984-e929f71bec22@gmail.com/


