### PR TITLE
Add `debug` feature: enables `tracing`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ nom = "8.0.0"
 nom_locate = "5.0.0"
 regex = "1.12.3"
 serde = { version = "1.0.228", features = ["derive"], optional = true }
-tracing = { version = "0.1.44", features = ["log"] }
+tracing = { version = "0.1.44", features = ["log"], optional = true }
 
 [dev-dependencies]
 criterion = { version = "0.8.2", features = ["html_reports"] }
@@ -46,9 +46,10 @@ name = "my_benchmark"
 harness = false
 
 [features]
-default = ["display", "hash", "serialize", "deserialize"]
+default = ["display", "debug", "hash", "serialize", "deserialize"]
 coreboot = ["dep:glob"]
 display = []
+debug = ["dep:tracing"]
 hash = []
 serialize = ["dep:serde"]
 deserialize = ["dep:serde"]

--- a/src/kconfig.rs
+++ b/src/kconfig.rs
@@ -8,6 +8,7 @@ use nom::{
 use serde::Deserialize;
 #[cfg(feature = "serialize")]
 use serde::Serialize;
+#[cfg(feature = "debug")]
 use tracing::debug;
 
 use crate::{
@@ -40,6 +41,7 @@ pub struct Kconfig {
 /// ```
 pub fn parse_kconfig(input: KconfigInput) -> IResult<KconfigInput, Kconfig> {
     let file: std::path::PathBuf = input.extra.file.clone();
+    #[cfg(feature = "debug")]
     debug!("Parsing file '{}'", file.display());
     let (input, result) = map(delimited(ws_comment, many0(parse_entry), ws(eof)), |d| {
         Kconfig {


### PR DESCRIPTION
Further shrinks the amount of dependencies, see the `cargo tree` for what tracing pulls in:
```
nom-kconfig v0.10.0
    └── tracing v0.1.44
        ├── log v0.4.29
        ├── pin-project-lite v0.2.17
        ├── tracing-attributes v0.1.31 (proc-macro)
        │   ├── proc-macro2 v1.0.106
        │   │   └── unicode-ident v1.0.24
        │   ├── quote v1.0.45
        │   │   └── proc-macro2 v1.0.106 (*)
        │   └── syn v2.0.117
        │       ├── proc-macro2 v1.0.106 (*)
        │       ├── quote v1.0.45 (*)
        │       └── unicode-ident v1.0.24
        └── tracing-core v0.1.36
            └── once_cell v1.21.4
```

I've left this enabled by default