### PR TITLE
Rename `coreboot` feature to `glob_wildcard`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## What's Changed in 0.11.0
+* chore: Release version v0.11.0 by @Mcdostone
+* feat: support for the kconfiglib by @Mcdostone
+* add debug feature: enables tracing by @julianbraha
+* ci: trying to secure CI by @Mcdostone
+* Changelog for v0.10.0 by @github-actions[bot] in [#140](https://github.com/Mcdostone/nom-kconfig/pull/140)
+* build(deps): bump rust-lang/crates-io-auth-action from 1.0.3 to 1.0.4 by @dependabot[bot] in [#139](https://github.com/Mcdostone/nom-kconfig/pull/139)
+* build(deps): bump codecov/codecov-action from 5.5.4 to 6.0.0 by @dependabot[bot] in [#138](https://github.com/Mcdostone/nom-kconfig/pull/138)
+* build(deps): bump bnjbvr/cargo-machete from db87f5ee388b462ee8c4311742246d599b78a00a to ac30a525c0a8d163a92d727b3ff079ee3f6ecb08 by @dependabot[bot] in [#137](https://github.com/Mcdostone/nom-kconfig/pull/137)
+
+### New Contributors
+* @julianbraha made their first contribution
+
+**Full Changelog**: https://github.com/Mcdostone/nom-kconfig/compare/v0.10.0...v0.11.0
+
 ## What's Changed in 0.10.0
 * Develop by @Mcdostone in [#136](https://github.com/Mcdostone/nom-kconfig/pull/136)
 * test: new integration test for linux-next by @Mcdostone

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,8 +46,8 @@ harness = false
 
 [features]
 default = ["display", "hash", "serialize", "deserialize", "kconfiglib"]
-coreboot = ["dep:glob", "named-choice"]
-kconfiglib = ["dep:glob", "named-choice"]
+glob_wildcard = ["dep:glob", "named-choice"]
+kconfiglib = ["glob_wildcard", "named-choice"]
 named-choice = []
 display = []
 debug = ["dep:tracing"]

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ There are plenty of other keywords in the Kconfig language, check out [the offic
  - When [`source`](https://www.kernel.org/doc/html/next/kbuild/kconfig-language.html#menu-entries) is met, it reads and parses the specified configuration file.
  - This library uses `clone()` a lot. Do not expect amazing performances.
  - This parser has been tested on the Linux kernel repository from [2.6.11](https://cdn.kernel.org/pub/linux/kernel/v2.6/linux-2.6.11.tar.xz) to [6.4.9](https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-6.4.9.tar.xz) (3733 versions).
- - There are cargo features for `coreboot` and `kconfiglib` compatibility. Enabling them adds support for some non-standard entries and attributes used by these projects.
+ - There are cargo features for `glob_wildcard` (used by coreboot, for example) and `kconfiglib` compatibility. Enabling them adds support for some non-standard entries and attributes used by these projects.
  
 
 ## Getting started

--- a/src/attribute/depends_on_test.rs
+++ b/src/attribute/depends_on_test.rs
@@ -4,7 +4,7 @@ use crate::{
     symbol::Symbol,
     Attribute,
 };
-#[cfg(feature = "coreboot")]
+#[cfg(feature = "glob_wildcard")]
 use crate::{
     attribute::{expression::CompareOperand, CompareExpression, CompareOperator},
     symbol::ConstantSymbol,
@@ -73,7 +73,7 @@ fn test_parse_depends_on_backslash() {
 
 /// https://github.com/coreboot/coreboot/blob/main/payloads/external/SeaBIOS/Kconfig#L159
 #[test]
-#[cfg(feature = "coreboot")]
+#[cfg(feature = "glob_wildcard")]
 fn test_parse_depends_on_with_minus_one() {
     assert_parsing_eq!(
         parse_depends_on,

--- a/src/entry/source/mod.rs
+++ b/src/entry/source/mod.rs
@@ -16,7 +16,6 @@ use nom::{
     IResult, Parser,
 };
 
-#[cfg(any(feature = "kconfiglib", feature = "coreboot"))]
 #[cfg(feature = "kconfiglib")]
 pub use self::{
     orsource::parse_orsource, orsource::OrSource, osource::parse_osource, osource::OSource,
@@ -29,16 +28,16 @@ use tracing::{debug, error};
 use crate::{kconfig::private_parse_kconfig, KconfigInput};
 use crate::{util::ws, Kconfig, KconfigFile};
 
-#[cfg(any(feature = "kconfiglib", feature = "coreboot"))]
+#[cfg(feature = "glob_wildcard")]
 pub use glob::glob;
 use std::collections::HashMap;
-#[cfg(any(feature = "kconfiglib", feature = "coreboot"))]
+#[cfg(feature = "glob_wildcard")]
 use std::path::PathBuf;
 
 #[cfg(test)]
 mod source_test;
 
-#[cfg(any(feature = "kconfiglib", feature = "coreboot"))]
+#[cfg(feature = "glob_wildcard")]
 enum JoinPathMode {
     Relative,
 
@@ -139,7 +138,7 @@ fn parse_source_kconfig(
     x
 }
 
-#[cfg(any(feature = "kconfiglib", feature = "coreboot"))]
+#[cfg(feature = "glob_wildcard")]
 fn expand_source_files<'a>(
     input: KconfigInput<'a>,
     file: &str,

--- a/src/entry/source/source.rs
+++ b/src/entry/source/source.rs
@@ -4,7 +4,7 @@ use serde::Deserialize;
 #[cfg(feature = "serialize")]
 use serde::Serialize;
 
-#[cfg(any(feature = "coreboot", feature = "kconfiglib"))]
+#[cfg(feature = "glob_wildcard")]
 use crate::entry::source::{expand_source_files, JoinPathMode};
 use crate::{
     entry::source::{parse_filepath, parse_source_kconfig},
@@ -30,7 +30,7 @@ pub fn parse_source(input: KconfigInput) -> IResult<KconfigInput, Source> {
     )))
     .parse(input)?;
 
-    #[cfg(any(feature = "coreboot", feature = "kconfiglib"))]
+    #[cfg(feature = "glob_wildcard")]
     {
         let expanded_files = expand_source_files(input.clone(), file, JoinPathMode::Root)?;
         let mut sources = vec![];
@@ -45,7 +45,7 @@ pub fn parse_source(input: KconfigInput) -> IResult<KconfigInput, Source> {
         Ok((input, Source { kconfigs: sources }))
     }
 
-    #[cfg(not(any(feature = "coreboot", feature = "kconfiglib")))]
+    #[cfg(not(feature = "glob_wildcard"))]
     {
         use std::path::PathBuf;
 

--- a/src/entry/source/source_test.rs
+++ b/src/entry/source/source_test.rs
@@ -63,7 +63,7 @@ fn test_parse_source_fail_to_parse() {
     assert!(res.is_err())
 }
 
-#[cfg(not(feature = "coreboot"))]
+#[cfg(not(feature = "glob_wildcard"))]
 #[test]
 fn test_parse_source_glob_not_supported_without_feature() {
     let res = parse_source(KconfigInput::new_extra(
@@ -76,7 +76,7 @@ fn test_parse_source_glob_not_supported_without_feature() {
     assert!(res.is_err())
 }
 
-#[cfg(feature = "coreboot")]
+#[cfg(feature = "glob_wildcard")]
 #[test]
 fn test_parse_source_glob_no_match_fails_with_feature() {
     let res = parse_source(KconfigInput::new_extra(

--- a/src/kconfig_test.rs
+++ b/src/kconfig_test.rs
@@ -6,17 +6,17 @@ use crate::{
     Attribute, Entry, Kconfig,
 };
 
-#[cfg(feature = "coreboot")]
+#[cfg(feature = "glob_wildcard")]
 use crate::attribute::expression::CompareOperand;
-#[cfg(feature = "coreboot")]
+#[cfg(feature = "glob_wildcard")]
 use crate::attribute::{r#macro::Macro, DefaultAttribute};
-#[cfg(feature = "coreboot")]
+#[cfg(feature = "glob_wildcard")]
 use crate::attribute::{AndExpression, Atom, CompareExpression, CompareOperator, Expression, Term};
 #[cfg(not(feature = "named-choice"))]
 use crate::entry::Choice;
-#[cfg(feature = "coreboot")]
+#[cfg(feature = "glob_wildcard")]
 use crate::symbol::ConstantSymbol;
-#[cfg(feature = "coreboot")]
+#[cfg(feature = "glob_wildcard")]
 use crate::Symbol;
 
 #[test]
@@ -78,7 +78,7 @@ endchoice
 }
 
 #[test]
-#[cfg(feature = "coreboot")]
+#[cfg(feature = "glob_wildcard")]
 /// https://github.com/Mcdostone/nom-kconfig/issues/107#issuecomment-3736187967
 fn test_parse_kconfig_bool() {
     let input = r#"

--- a/tests/source_glob.rs
+++ b/tests/source_glob.rs
@@ -1,10 +1,10 @@
 use std::path::PathBuf;
 
-#[cfg(feature = "coreboot")]
+#[cfg(feature = "glob_wildcard")]
 use nom_kconfig::{entry::config::Config, Entry};
 use nom_kconfig::{error::Error, parse_kconfig, Kconfig, KconfigFile, KconfigInput};
 
-#[cfg(feature = "coreboot")]
+#[cfg(feature = "glob_wildcard")]
 #[test]
 fn test_source_glob_expands_and_parses_children() {
     let (_content, result) = parse_test_file("source-main.Kconfig");
@@ -38,7 +38,7 @@ fn test_source_glob_expands_and_parses_children() {
 //     assert!(result.is_err());
 // }
 
-#[cfg(feature = "coreboot")]
+#[cfg(feature = "glob_wildcard")]
 #[test]
 fn test_source_literal_path_works_with_glob_feature() {
     let (_content, result) = parse_test_file("source-main-literal.Kconfig");
@@ -68,7 +68,7 @@ fn parse_test_file(file_name: &str) -> (String, Result<(KconfigInput<'_>, Kconfi
     )
 }
 
-#[cfg(feature = "coreboot")]
+#[cfg(feature = "glob_wildcard")]
 fn source_entry(result: &nom_kconfig::Kconfig) -> &nom_kconfig::entry::Source {
     match result.entries.first() {
         Some(Entry::Source(source)) => source,
@@ -76,7 +76,7 @@ fn source_entry(result: &nom_kconfig::Kconfig) -> &nom_kconfig::entry::Source {
     }
 }
 
-#[cfg(feature = "coreboot")]
+#[cfg(feature = "glob_wildcard")]
 fn config_symbol(entry: &Entry) -> Option<&str> {
     match entry {
         Entry::Config(Config { symbol, .. }) => Some(symbol.as_str()),


### PR DESCRIPTION
I think, since the glob wildcard `*` is used by more Kconfig projects than coreboot, it makes more sense to call it what it is directly.

Also, since the recent changes to how variables are handled in `nom-kconfig` v0.11.0 (now required to set them to parse Linux due to the `source "arch/$(SRCARCH)/Kconfig"` in `linux/arch/Kconfig`), my use case now takes advantage of wildcards to match all of the architectures in one pass by setting `SRCARCH` to `*`.

By the way, as a user, I quite like the recent changes!