### PR TITLE
Runtime improvements: use CoW for scoping, avoid unnecessary clone()

### DIFF
--- a/src/entry/source/mod.rs
+++ b/src/entry/source/mod.rs
@@ -80,7 +80,7 @@ fn parse_source_kconfig(
                 input.extra.full_path().display()
             );
             return Ok((
-                input.extra.vars().clone(),
+                input.extra.vars(),
                 Kconfig {
                     file: source_kconfig_file.full_path().display().to_string(),
                     entries: vec![],
@@ -96,7 +96,7 @@ fn parse_source_kconfig(
         &source_content,
         source_kconfig_file.clone(),
     )) {
-        Ok((d, kconfig)) => Ok((d.extra.local_vars, kconfig)),
+        Ok((d, kconfig)) => Ok(((*d.extra.local_vars).clone(), kconfig)),
         Err(e) => {
             //debug!("Variables are {:?}", input.extra.vars());
             //error!(

--- a/src/entry/variable.rs
+++ b/src/entry/variable.rs
@@ -105,8 +105,7 @@ pub fn parse_variable_identifier(input: KconfigInput) -> IResult<KconfigInput, V
 }
 
 pub fn parse_variable_assignment(input: KconfigInput) -> IResult<KconfigInput, VariableAssignment> {
-    let mut new_extra = input.extra.clone();
-    let result = map(
+    let (mut remaining, assignment) = map(
         (
             ws(parse_variable_identifier),
             ws(parse_assign),
@@ -118,16 +117,14 @@ pub fn parse_variable_assignment(input: KconfigInput) -> IResult<KconfigInput, V
             right: r,
         },
     )
-    .parse(input);
+    .parse(input)?;
 
     // If the parsing is successful, we add the variable assignment to the local variables of the KconfigFile.
     // variables can be used by the preprocessor.
-    if let Ok((mut remaining, assignment)) = result {
-        new_extra.add_local_var(assignment.identifier.raw(), assignment.right.raw());
-        remaining.extra = new_extra;
-        return Ok((remaining, assignment.clone()));
-    }
-    result
+    remaining
+        .extra
+        .add_local_var(assignment.identifier.raw(), assignment.right.raw());
+    Ok((remaining, assignment))
 }
 
 pub fn parse_assign(input: KconfigInput<'_>) -> IResult<KconfigInput<'_>, &str> {

--- a/src/kconfig_file.rs
+++ b/src/kconfig_file.rs
@@ -16,7 +16,8 @@
 //!     let kconfig_file = KconfigFile::new_with_vars(
 //!         PathBuf::from("/tmp/linux-6.4.9"),
 //!         PathBuf::from("/tmp/linux-6.4.9/Kconfig"),
-//!         &variables
+//!         &variables,
+//!         &HashMap::default(),
 //!     );
 //!     let input = kconfig_file.read_to_string().unwrap();
 //!     let kconfig = parse_kconfig(KconfigInput::new_extra(&input, kconfig_file));
@@ -27,6 +28,7 @@
 
 use std::collections::HashMap;
 use std::path::PathBuf;
+use std::rc::Rc;
 use std::{fs, io};
 
 /// Represents a Kconfig file.
@@ -38,9 +40,9 @@ pub struct KconfigFile {
     /// The path the the Kconfig you want to parse.
     pub file: PathBuf,
     /// Externally-specified variables to use when including child source files
-    pub global_vars: HashMap<String, String>,
-    pub local_vars: HashMap<String, String>,
-    pub external_functions: HashMap<String, String>,
+    pub global_vars: Rc<HashMap<String, String>>,
+    pub local_vars: Rc<HashMap<String, String>>,
+    pub external_functions: Rc<HashMap<String, String>>,
     pub depth: usize,
     pub parent_file: Option<PathBuf>,
 }
@@ -50,9 +52,9 @@ impl KconfigFile {
         Self {
             root_dir,
             file,
-            global_vars: HashMap::new(),
-            local_vars: HashMap::new(),
-            external_functions: HashMap::new(),
+            global_vars: Rc::new(HashMap::new()),
+            local_vars: Rc::new(HashMap::new()),
+            external_functions: Rc::new(HashMap::new()),
             depth: 0,
             parent_file: None,
         }
@@ -67,25 +69,26 @@ impl KconfigFile {
         Self {
             root_dir,
             file,
-            global_vars: global_vars
-                .iter()
-                .map(|(s1, s2)| (s1.as_ref().to_string(), s2.as_ref().to_string()))
-                .collect(),
-            local_vars: local_vars
-                .iter()
-                .map(|(s1, s2)| (s1.as_ref().to_string(), s2.as_ref().to_string()))
-                .collect(),
-            external_functions: HashMap::new(),
+            global_vars: Rc::new(
+                global_vars
+                    .iter()
+                    .map(|(s1, s2)| (s1.as_ref().to_string(), s2.as_ref().to_string()))
+                    .collect(),
+            ),
+            local_vars: Rc::new(
+                local_vars
+                    .iter()
+                    .map(|(s1, s2)| (s1.as_ref().to_string(), s2.as_ref().to_string()))
+                    .collect(),
+            ),
+            external_functions: Rc::new(HashMap::new()),
             depth: 0,
             parent_file: None,
         }
     }
 
-    pub fn with_external_functions(
-        mut self,
-        _external_functions: &HashMap<String, String>,
-    ) -> Self {
-        self.external_functions = self.external_functions.clone();
+    pub fn with_external_functions(mut self, external_functions: &HashMap<String, String>) -> Self {
+        self.external_functions = Rc::new(external_functions.clone());
         self
     }
 
@@ -98,8 +101,8 @@ impl KconfigFile {
     }
 
     pub fn vars(&self) -> HashMap<String, String> {
-        let mut variables = self.global_vars.clone();
-        variables.extend(self.local_vars.clone());
+        let mut variables = (*self.global_vars).clone();
+        variables.extend((*self.local_vars).clone());
         variables
     }
 
@@ -116,23 +119,33 @@ impl KconfigFile {
     }
 
     pub fn set_global_vars<S: AsRef<str>>(&mut self, vars: &[(S, S)]) {
-        self.global_vars = vars
-            .iter()
-            .map(|(s1, s2)| (s1.as_ref().to_string(), s2.as_ref().to_string()))
-            .collect();
+        self.global_vars = Rc::new(
+            vars.iter()
+                .map(|(s1, s2)| (s1.as_ref().to_string(), s2.as_ref().to_string()))
+                .collect(),
+        );
     }
 
     pub fn add_local_var<S: AsRef<str>>(&mut self, key: S, value: S) {
-        self.local_vars
-            .insert(key.as_ref().to_string(), value.as_ref().to_string());
+        let mut new_map = (*self.local_vars).clone();
+        new_map.insert(key.as_ref().to_string(), value.as_ref().to_string());
+        self.local_vars = Rc::new(new_map);
     }
 
     pub fn add_local_vars(&mut self, new_vars: HashMap<String, String>) {
-        self.local_vars.extend(new_vars);
+        if new_vars.is_empty() {
+            return;
+        }
+        let mut new_map = (*self.local_vars).clone();
+        new_map.extend(new_vars);
+        self.local_vars = Rc::new(new_map);
     }
 
     pub fn preprocess_content(&self, content: String) -> String {
         let variables = self.vars();
+        if variables.is_empty() {
+            return content;
+        }
         let mut file_copy = content.clone();
         for (var_name, var_value) in variables {
             file_copy = file_copy.replace(&format!("$({var_name})"), &var_value);


### PR DESCRIPTION
This reduces the time to parse x86 Linux from 90 seconds to 15 seconds, on my laptop. 

There's a few optimizations here, but the big one is to use reference counting to implement copy-on-write for the scope, rather than always cloning.

Also, there's two early returns now to avoid calling `clone()` unnecessarily:
1. in `parse_variable_assignment()` to avoid `let mut new_extra = input.extra.clone();`,
2. in `preprocess_content()` to avoid `let mut file_copy = content.clone();`

Not sure if this is the best we can do, but it at least partially resolves #156 and #24 