### PR TITLE
Fix missing tracing dependency from tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ tracing = { version = "0.1.44", features = ["log"], optional = true }
 criterion = { version = "0.5.1", features = ["html_reports"] }
 walkdir = "2.5.0"
 reqwest = { version = "0.13.3", features = ["blocking"] }
+tracing = { version = "0.1.44", features = ["log"] }
 tracing-subscriber = "0.3.23"
 clap = { version = "4.4.18", features = ["derive"] }
 


### PR DESCRIPTION
PR #152 broke `cargo test` when the `debug` feature is disabled, because several examples use `tracing`.

This is currently blocking fedora packaging (issue #149 and PR #163)